### PR TITLE
Update package.json to replace mockserver dependency

### DIFF
--- a/src/sustainable-smart-factory-app/app/predictive-maintenance/equipment-conditions-alp/package.json
+++ b/src/sustainable-smart-factory-app/app/predictive-maintenance/equipment-conditions-alp/package.json
@@ -27,13 +27,12 @@
 		"@ui5/logger": "^2.0.1",
 		"@sap/ux-ui5-tooling": "1",
 		"rimraf": "3.0.2",
-		"@sap/ux-specification": "UI5-1.99",
-		"@sap/ux-ui5-fe-mockserver-middleware": "1"
+		"@sap-ux/ui5-middleware-fe-mockserver": "2"
 	},
 	"ui5": {
 		"dependencies": [
 			"@sap/ux-ui5-tooling",
-			"@sap/ux-ui5-fe-mockserver-middleware"
+			"@sap-ux/ui5-middleware-fe-mockserver"
 		]
 	}
 }


### PR DESCRIPTION
As `@sap/ux-ui5-fe-mockserver-middleware` is deprecated since a quadruple of year I updated to the correct dependency `@sap-ux/ui5-middleware-fe-mockserver`.

Also specification dependency is no longer needed for `@sap/ux-ui5-tooling`.