### PR TITLE
Update package.json dependencies for mock server

### DIFF
--- a/src/sustainable-smart-factory-app/app/defeat-detection/cv-quality-records-alp/package.json
+++ b/src/sustainable-smart-factory-app/app/defeat-detection/cv-quality-records-alp/package.json
@@ -27,8 +27,7 @@
 		"@ui5/logger": "^2.0.1",
 		"@sap/ux-ui5-tooling": "1",
 		"rimraf": "3.0.2",
-		"@sap/ux-specification": "UI5-1.100",
-		"@sap/ux-ui5-fe-mockserver-middleware": "1"
+		"@sap-ux/ui5-middleware-fe-mockserver": "2"
 	},
 	"ui5": {
 		"dependencies": [


### PR DESCRIPTION
As `@sap/ux-ui5-fe-mockserver-middleware` is deprecated since a quadruple of year I updated to the correct dependency `@sap-ux/ui5-middleware-fe-mockserver`.

Also specification dependency is no longer needed for `@sap/ux-ui5-tooling`.